### PR TITLE
Don't default to Java descriptor decompilation

### DIFF
--- a/protodec.cpp
+++ b/protodec.cpp
@@ -78,6 +78,7 @@ struct CommandOptions {
         , mPrint(false)
         , mSchema(false)
         , mShowUsage(false)
+        , mJava(false)
     {
         for (int i = 1; i < argc; ++i) {
             if (!strcmp(argv[i], "--help")) {


### PR DESCRIPTION
Looks like mJava is currently defaulting to `true` - this should default it to `false` so that `--java` works like it should on the CLI.  Thanks!